### PR TITLE
Fix transfer failed  by adding delegatedWithdrawalCapability to Account State

### DIFF
--- a/lib/common/CursorBuffer.ts
+++ b/lib/common/CursorBuffer.ts
@@ -59,4 +59,18 @@ export class CursorBuffer {
 
     return value;
   }
+
+  /**
+   * Reads 1 byte
+   *
+   */
+  public readBool(): boolean {
+    const value = this.dataView.getUint8(this.bytePositon);
+    console.log(`readBool ${value}`)
+    this.bytePositon += 1;
+    if(value !== 0 && value !== 1) {
+      throw(`bool must be 0 or 1, found ${value}`)
+    }
+    return value !== 0;
+  }
 }

--- a/lib/wallet/Accounts.ts
+++ b/lib/wallet/Accounts.ts
@@ -23,6 +23,7 @@ export class AccountState {
       new BigNumber(0),
       new BigNumber(0),
       new BigNumber(0),
+      true
     );
   }
 
@@ -32,17 +33,19 @@ export class AccountState {
     const authenticationKeyLen = cursor.read32();
     const authenticationKey = cursor.readXBytes(authenticationKeyLen);
     const balance = cursor.read64();
+    const delegatedWithdrawalCapability = cursor.readBool();
     const receivedEventsCount = cursor.read64();
     const sentEventsCount = cursor.read64();
     const sequenceNumber = cursor.read64();
 
-    return new AccountState(authenticationKey, balance, receivedEventsCount, sentEventsCount, sequenceNumber);
+    return new AccountState(authenticationKey, balance, receivedEventsCount, sentEventsCount, sequenceNumber, delegatedWithdrawalCapability);
   }
   public readonly authenticationKey: Uint8Array;
   public readonly balance: BigNumber;
   public readonly receivedEventsCount: BigNumber;
   public readonly sentEventsCount: BigNumber;
   public readonly sequenceNumber: BigNumber;
+  public readonly delegatedWithdrawalCapability: boolean;
 
   private constructor(
     authenticationKey: Uint8Array,
@@ -50,12 +53,14 @@ export class AccountState {
     receivedEventsCount: BigNumber,
     sentEventsCount: BigNumber,
     sequenceNumber: BigNumber,
+    delegatedWithdrawalCapability: boolean,
   ) {
     this.balance = balance;
     this.sequenceNumber = sequenceNumber;
     this.authenticationKey = authenticationKey;
     this.sentEventsCount = sentEventsCount;
     this.receivedEventsCount = receivedEventsCount;
+    this.delegatedWithdrawalCapability = delegatedWithdrawalCapability;
   }
 }
 


### PR DESCRIPTION
Fix bug when transfer failed for 1-n transactions, for example new fresh account will successfully transfer once and other after that will failed.

Because of Account State changing, adding new delegatedWithdrawalCapability, when the problem fixed.