### PR TITLE
Added react-native alias to map Node import to Browser import.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,12 @@
     "build/**/*",
     "lib/**/*"
   ],
+  "react-native": {
+    "./build/client/Node.js": "./build/client/Browser.js"
+  },
+  "browser": {
+    "./build/client/Node.js": "./build/client/Browser.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/kulapio/libra-core.git"


### PR DESCRIPTION
This fixes the issue in react native
error: bundling failed: Error: Unable to resolve module memcpy from ....\node_modules\bytebuffer\dist\bytebuffer-node.js: Module memcpy does not exist in the Haste module map