### PR TITLE
fix bug cannot decode gettransaction

### DIFF
--- a/lib/client/Decoder.ts
+++ b/lib/client/Decoder.ts
@@ -46,6 +46,8 @@ export class ClientDecoder {
     const signedTransactionProtobuf = signedTransactionWP.getTransaction() as Transaction
     const rawTxnBytes = signedTransactionProtobuf.getTransaction_asU8()
     const transactionCursor = new CursorBuffer(rawTxnBytes)
+    // skip first 4 byte
+    transactionCursor.read32()
     const transaction = LCSDeserialization.getRawTransaction(transactionCursor)
     const publicKey = LCSDeserialization.getByteArray(transactionCursor)
     const signature = LCSDeserialization.getByteArray(transactionCursor)


### PR DESCRIPTION
fix bug method getAccountTransaction. The root cause is the new rawtransaction from updateToLatestLedger response has append first 4 byte.
![image](https://user-images.githubusercontent.com/760108/68070804-b1724d00-fda5-11e9-9f3c-08fe6afd795a.png)
